### PR TITLE
Fix undefined $view / add support for button types

### DIFF
--- a/src/Impersonate.php
+++ b/src/Impersonate.php
@@ -3,16 +3,19 @@
 namespace STS\FilamentImpersonate;
 
 use Filament\Facades\Filament;
-use Filament\Tables\Actions\IconButtonAction;
+use Filament\Tables\Actions\Action;
 use Illuminate\Http\RedirectResponse;
 use Lab404\Impersonate\Services\ImpersonateManager;
 use Livewire\Redirector;
 
-class Impersonate extends IconButtonAction
+class Impersonate extends Action
 {
     protected function setUp(): void
     {
+        parent::setUp();
+        
         $this
+            ->iconButton()
             ->icon('impersonate::icon')
             ->action(fn($record) => static::impersonate($record))
             ->hidden(fn($record) => !static::allowed(Filament::auth()->user(), $record));


### PR DESCRIPTION
In a recent Filament version, we changed the way that action views were handled. Before, users needed to use a different class depending on which view they were using - `IconButtonAction`, `ButtonAction`, `LinkAction`, etc. We moved the view path from a `$view` property to a dedicated method i.e. `button()`, `link()`, `iconButton()`, which is called from `setUp()`.

This was not a breaking change, since we kept the `IconButtonAction` etc classes and made them work with the new methods. However, this package extends `IconButtonAction` and overrides the `setUp()` method, without calling `parent::setUp()` (which is a requirement).

TLDR: to fix the issue, we just needed to add `parent::setUp()` to the `setUp()` method.

However, I've added a new feature to your package at the same time - instead of extending `IconButtonAction`, I changed it so you now extend the base `Action` class instead. Users can now customise how the Impersonate button looks!

```php
Impersonate::make('impersonate') // iconButton() by default
Impersonate::make('impersonate')->button()
Impersonate::make('impersonate')->link()
```