### PR TITLE
Use default name for action

### DIFF
--- a/src/Impersonate.php
+++ b/src/Impersonate.php
@@ -10,6 +10,11 @@ use Livewire\Redirector;
 
 class Impersonate extends Action
 {
+    public static function make(string $name = 'impersonate'): static
+    {
+        return parent::make($name);
+    }
+    
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
Micro improvement, but as this action is usually only used once, I think a default name saves some chars 😅