### PR TITLE
Allow both top and bottom positioning for banner

### DIFF
--- a/config/filament-impersonate.php
+++ b/config/filament-impersonate.php
@@ -14,6 +14,9 @@ return [
         'style' => env('FILAMENT_IMPERSONATE_BANNER_STYLE', 'dark'),
 
         // Turn this off if you want `absolute` positioning, so the banner scrolls out of view
-        'fixed' => env('FILAMENT_IMPERSONATE_BANNER_FIXED', true)
-    ]
+        'fixed' => env('FILAMENT_IMPERSONATE_BANNER_FIXED', true),
+
+        // Currently supports 'top' and 'bottom'.
+        'position' => env('FILAMENT_IMPERSONATE_BANNER_POSITION', 'top'),
+    ],
 ];

--- a/resources/views/auto-inject-banner.blade.php
+++ b/resources/views/auto-inject-banner.blade.php
@@ -1,8 +1,1 @@
 <x-impersonate::banner :fixed="true"/>
-@if($isFilament)
-    <style>
-        body > div > aside {
-            padding-top: 50px;
-        }
-    </style>
-@endif

--- a/resources/views/components/banner.blade.php
+++ b/resources/views/components/banner.blade.php
@@ -10,8 +10,8 @@ $position = $position ?? config('filament-impersonate.banner.position');
 @endphp
 
 <style>
-    html {
-        margin-top: 50px;
+    aside, body {
+        margin-{{ $position }}: 50px;
     }
 
     #impersonate-banner {
@@ -51,7 +51,7 @@ $position = $position ?? config('filament-impersonate.banner.position');
     }
 
     @media print{
-        html {
+        aside, body {
             margin-top: 0;
         }
 

--- a/resources/views/components/banner.blade.php
+++ b/resources/views/components/banner.blade.php
@@ -1,4 +1,4 @@
-@props(['style', 'display', 'fixed'])
+@props(['style', 'display', 'fixed', 'position'])
 
 @if(app('impersonate')->isImpersonating())
 
@@ -6,6 +6,7 @@
 $style = $style ?? config('filament-impersonate.banner.style');
 $display = $display ?? Filament\Facades\Filament::getUserName(auth()->user());
 $fixed = $fixed ?? config('filament-impersonate.banner.fixed');
+$position = $position ?? config('filament-impersonate.banner.position');
 @endphp
 
 <style>
@@ -16,7 +17,7 @@ $fixed = $fixed ?? config('filament-impersonate.banner.fixed');
     #impersonate-banner {
         position: {{ $fixed ? 'fixed' : 'absolute' }};
         height: 50px;
-        top: 0;
+        {{ $position }}: 0;
         width: 100%;
         display: flex;
         column-gap: 20px;

--- a/resources/views/components/banner.blade.php
+++ b/resources/views/components/banner.blade.php
@@ -10,8 +10,12 @@ $position = $position ?? config('filament-impersonate.banner.position');
 @endphp
 
 <style>
-    aside, body {
+    html {
         margin-{{ $position }}: 50px;
+    }
+
+    body.filament-body > div.filament-app-layout > aside.filament-sidebar {
+        padding-{{ $position }}: 50px;
     }
 
     #impersonate-banner {

--- a/src/Middleware/ImpersonationBanner.php
+++ b/src/Middleware/ImpersonationBanner.php
@@ -30,8 +30,6 @@ class ImpersonationBanner
 
     protected function bannerHtml($request)
     {
-        return view('impersonate::auto-inject-banner', [
-            'isFilament' => Str::startsWith($request->path(), config('filament.path')),
-        ])->render();
+        return view('impersonate::auto-inject-banner')->render();
     }
 }


### PR DESCRIPTION
This PR allows the user to specify the position (either `top` or `bottom`) for the banner. This will continue to default to the top.