### PR TITLE
Documentation improvement for table actions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ class UserResource extends Resource {
 
 If you already have an `actions()` method defined in your resource, place the `Impersonate::make` directly into the `actions` array.
 
-```return $table
+```
+return $table
     ->columns([
         // ...
     ])

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ class UserResource extends Resource {
 
 If you already have an `actions()` method defined in your resource, place the `Impersonate::make` directly into the `actions` array.
 
-```
+```php
 return $table
     ->columns([
         // ...
@@ -54,7 +54,7 @@ return $table
     ->actions([
         // ...
         Impersonate::make('impersonate'), // <---
-    ])
+    ]);
 ```
     
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ class UserResource extends Resource {
     }
 ```
 
+If you already have an `actions()` method defined in your resource, place the `Impersonate::make` directly into the `actions` array.
+
+```return $table
+    ->columns([
+        // ...
+    ])
+    ->actions([
+        // ...
+        Impersonate::make('impersonate'), // <---
+    ])
+```
+    
+
 ### 2. Add the banner to your blade layout
 
 The only other step is to display a notice in your app whenever you are impersonating another user. Open up your master layout file and add `<x-impersonate::banner/>` before the closing `</body>` tag.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ class UserResource extends Resource {
     }
 ```
 
-If you already have an `actions()` method defined in your resource, place the `Impersonate::make` directly into the `actions` array.
+If you already have an `actions()` method defined for your table, place the `Impersonate::make` directly into the `actions` array.
 
 ```php
 return $table

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ return $table
         // ...
     ])
     ->actions([
-        // ...
         Impersonate::make('impersonate'), // <---
+        // ...
     ]);
 ```
     


### PR DESCRIPTION
I noticed that when I had an `actions()` method defined in my resource table, it overwrote the `prependActions()` array where the `Impersonate::make` is usually placed. 

This is just a small documentation change that makes it clear that the `Impersonate::make` can also be placed inside the `actions()` array.