### PR TITLE
Update action name behavior

### DIFF
--- a/src/Impersonate.php
+++ b/src/Impersonate.php
@@ -10,9 +10,9 @@ use Livewire\Redirector;
 
 class Impersonate extends Action
 {
-    public static function make(?string $name = 'impersonate'): static
+    public static function getDefaultName(): ?string
     {
-        return parent::make($name);
+        return 'impersonate';
     }
     
     protected function setUp(): void


### PR DESCRIPTION
Use action getDefaultName() to be able to use in test properly.

```php
    livewire(ListAdmins::class)
        ->callTableAction(Impersonate::class, $admin);
```