### PR TITLE
✨ Can use different guard and redirect to for `Impersonate` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ return $table
         // ...
     ]);
 ```
+
+You can also define a `guard` and `redirectTo` for the action:
+
+```php
+Impersonate::make('impersonate')
+    ->guard('another-guard')
+    ->redirectTo(route('some.other.route'));
+```
     
 
 ### 2. Add the banner to your blade layout


### PR DESCRIPTION
This PR aims to add `guard` and `redirectTo` customization for `Impersonate` action.

```php
Impersonate::make('impersonate')
    ->guard('another-guard')
    ->redirectTo(route('some.other.route'));
```

This resolves https://github.com/stechstudio/filament-impersonate/issues/15.