### PR TITLE
Allow to customise impersonation back_to URL

### DIFF
--- a/src/Concerns/Impersonates.php
+++ b/src/Concerns/Impersonates.php
@@ -14,6 +14,8 @@ trait Impersonates
 
     protected Closure|string|null $redirectTo = null;
 
+    protected Closure|string|null $backTo = null;
+
     public static function getDefaultName(): ?string
     {
         return 'impersonate';
@@ -33,6 +35,13 @@ trait Impersonates
         return $this;
     }
 
+    public function backTo(Closure|string $backTo): self
+    {
+        $this->backTo = $backTo;
+
+        return $this;
+    }
+
     public function getGuard(): string
     {
         return $this->evaluate($this->guard) ?? config('filament-impersonate.guard');
@@ -41,6 +50,11 @@ trait Impersonates
     public function getRedirectTo(): string
     {
         return $this->evaluate($this->redirectTo) ?? config('filament-impersonate.redirect_to');
+    }
+
+    public function getBackTo(): ?string
+    {
+        return $this->evaluate($this->backTo);
     }
 
     protected function canBeImpersonated($target): bool
@@ -60,7 +74,7 @@ trait Impersonates
         }
 
         session()->put([
-            'impersonate.back_to' => request('fingerprint.path'),
+            'impersonate.back_to' => $this->getBackTo() ?? request('fingerprint.path'),
             'impersonate.guard' => $this->getGuard()
         ]);
 


### PR DESCRIPTION
This PR adds a `backTo` customisation for the `Impersonate` action:

```php
Impersonate::make('impersonate')
    ->backTo(route('some.specific.route')),
```

Just like with different guards (added in https://github.com/stechstudio/filament-impersonate/pull/22), Filament can potentially be used with a different domain (or subdomain). In such cases, when leaving impersonation, the impersonating user may be redirected to a non-existing URL. Here's an example:
- Let's assume we've defined our `config('filament.domain')` as `admin.localhost`, which is different from the default app's domain.
- Other routes, that are not part of Filament use the default app's domain. Imagine it's just `localhost` for simplicity.
- Currently, the default `request('fingerprint.path')` value that is used in the session key `impersonate.back_to`, would redirect the Filament user back to `localhost/` (because it only uses the **path**, not the URL)
- Now, with the ability to modify the `impersonate.back_to` session key, it's possible to pass the full Filament URL, for example `static::getUrl('index')`, which generates a full URL with the correct domain