### PR TITLE
Leave impersonation event

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,11 +1,18 @@
 <?php
+
+use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Route;
 use Lab404\Impersonate\Services\ImpersonateManager;
+use STS\FilamentImpersonate\Events\LeaveImpersonate;
 
-Route::get('filament-impersonate/leave', function() {
-    if(!app(ImpersonateManager::class)->isImpersonating()) {
+Route::get('filament-impersonate/leave', function () {
+    if (! app(ImpersonateManager::class)->isImpersonating()) {
         return redirect('/');
     }
+
+    event(new LeaveImpersonate(
+        Filament::auth()->user()
+    ));
 
     app(ImpersonateManager::class)->leave();
 

--- a/src/Events/LeaveImpersonate.php
+++ b/src/Events/LeaveImpersonate.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace STS\FilamentImpersonate\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class LeaveImpersonate
+{
+    use Dispatchable;
+
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+}


### PR DESCRIPTION
In my case, I set the session for my application logic while impersonating, and couldn't reset the session back when leaving the impersonation.

With this, I don't have to make unnecessary logic just to reset the session.

It won't break anything because it's just an event.