### PR TITLE
z-index banner below notification

### DIFF
--- a/resources/views/components/banner.blade.php
+++ b/resources/views/components/banner.blade.php
@@ -50,7 +50,7 @@ $flipped = $default === 'dark' ? 'light' : 'dark';
         background-color: var(--impersonate-{{ $default }}-bg-color);
         color: var(--impersonate-{{ $default }}-text-color);
         border-{{ $borderPosition }}: 1px solid var(--impersonate-{{ $default }}-border-color);
-        z-index: 1000;
+        z-index: 45;
     }
 
     @if($style === 'auto')


### PR DESCRIPTION
Notifications in filament have a z-index of 50. This makes them appear below the banner. When notifications are persistent the close button in not visible. By reducing the z-index to 45 the banner is still above all filament elements except the notifications + some spare room just in case. 