### PR TITLE
fix exception  with multi guard auth   &   filament multipanel

### DIFF
--- a/resources/views/components/banner.blade.php
+++ b/resources/views/components/banner.blade.php
@@ -3,7 +3,7 @@
 @if(app('impersonate')->isImpersonating())
 
 @php
-$display = $display ?? Filament\Facades\Filament::getUserName(Filament\Facades\Filament::auth()->user());
+$display = $display ?? (!is_null(\Filament\Facades\Filament::auth()->user()) ? Filament\Facades\Filament::getUserName(Filament\Facades\Filament::auth()->user()) : '');
 $fixed = $fixed ?? config('filament-impersonate.banner.fixed');
 $position = $position ?? config('filament-impersonate.banner.position');
 $borderPosition = $position === 'top' ? 'bottom' : 'top';


### PR DESCRIPTION
FIX TypeError



`
Filament\FilamentManager::getUserName(): Argument #1 ($user) must be of type Illuminate\Database\Eloquent\Model|Illuminate\Contracts\Auth\Authenticatable, null given, called in /var/www/html/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php on line 355
`


The error can be reproduced as follows:


1.   Create 2  guards   /config/auth.php

```php

    'guards' => [
        'web' => [
            'driver' => 'session',
            'provider' => 'users',
        ],
        'company' => [
            'driver' => 'session',
            'provider' => 'users',
        ],
    ],

```



2.   One panel uses the default guard. Second custom, like this

```php

    public function panel(Panel $panel): Panel
    {
        return $panel
           // ......
            ->path('company')
            ->authGuard('company')
            // ......
            ;
    }


```



3. From default guards try to impersonate. 

```php

    public static function table(Table $table): Table
    {
        return $table
             // .....
            ->actions([
                Impersonate::make('Login as')->guard('company')->redirectTo('/company/'),
            ])
    }

```


4. Open the  URL  for the default guard ...  and you will see an Exception 



Perhaps this can be fixed through the config /config/filament-impersonate.php  but I'm not sure.




