### PR TITLE
backTo() - Fallback to referer when fingerprint.path doesn't exist

### DIFF
--- a/src/Concerns/Impersonates.php
+++ b/src/Concerns/Impersonates.php
@@ -74,7 +74,7 @@ trait Impersonates
         }
 
         session()->put([
-            'impersonate.back_to' => $this->getBackTo() ?? request('fingerprint.path') ?? Filament::getCurrentPanel()->getUrl(),
+            'impersonate.back_to' => $this->getBackTo() ?? request('fingerprint.path', request()->header('referer')) ?? Filament::getCurrentPanel()->getUrl(),
             'impersonate.guard' => $this->getGuard()
         ]);
 


### PR DESCRIPTION
Thank you for the great package!

We have encountered an issue when leaving impersonation after upgrading to Filament 3 + Livewire 3.

Upon leaving impersonation, the user is always redirected back to `Filament::getCurrentPanel()->getUrl() - /admin` due to `fingerprint.path` always being `null`.

We have got round this issue for now by using `->backTo()`, but i believe we could fix the problem by falling back to the referer.

I've been running the referrer changes locally and everything seems to be working as expected 👍 

