### PR TITLE
Default banner hook config value

### DIFF
--- a/src/FilamentImpersonateServiceProvider.php
+++ b/src/FilamentImpersonateServiceProvider.php
@@ -38,7 +38,7 @@ class FilamentImpersonateServiceProvider extends PackageServiceProvider
     public function bootingPackage(): void
     {
         FilamentView::registerRenderHook(
-            config('filament-impersonate.banner.render_hook'),
+            config('filament-impersonate.banner.render_hook', 'panels::body.start'),
             static fn (): string => Blade::render("<x-filament-impersonate::banner/>")
         );
 


### PR DESCRIPTION
Fixes #67 by providing a default value to the `config()` call in FilamentImpersonateServiceProvider.
