### PR TITLE
Fix: TableAction dont work with Table Widgets

### DIFF
--- a/src/Tables/Actions/Impersonate.php
+++ b/src/Tables/Actions/Impersonate.php
@@ -17,6 +17,7 @@ class Impersonate extends Action
             ->label(__('filament-impersonate::action.label'))
             ->iconButton()
             ->icon('impersonate-icon')
+            ->before(fn (Component $livewire) => $livewire->dispatchFormEvent(false))
             ->action(fn ($record) => $this->impersonate($record))
             ->hidden(fn ($record) => !$this->canBeImpersonated($record));
     }


### PR DESCRIPTION
If you have a table in which there are widgets that interact with the table(`InteractsWithPageTable`) when executing the impersonate action another widget event is sent, which causes that the user is not redirected correctly.

To solve this, in the action of the table you have to add that the impersonate action emits Livewire events.