### PR TITLE
Support multi panels with multi auth guards 

### DIFF
--- a/resources/views/components/banner.blade.php
+++ b/resources/views/components/banner.blade.php
@@ -1,6 +1,6 @@
 @props(['style', 'display', 'fixed', 'position'])
 
-@if(app('impersonate')->isImpersonating())
+@if(app('impersonate')->isImpersonating() && app('impersonate')->getImpersonatorGuardUsingName() === filament()->getCurrentPanel()->getAuthGuard())
 
 @php
 $display = $display ?? Filament\Facades\Filament::getUserName(Filament\Facades\Filament::auth()->user());


### PR DESCRIPTION
Support multi panels with multi auth guards 
this prevent the banner in the Impersonator panel and prevent the issue 

Filament\FilamentManager::getUserName(): Argument #1 ($user) must be of type Illuminate\Database\Eloquent\Model|Illuminate\Contracts\Auth\Authenticatable, null given

Fixes #87 