### PR TITLE
Replace inaccurate Spanish translation

### DIFF
--- a/resources/lang/es/action.php
+++ b/resources/lang/es/action.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    'label' => 'Hacerse pasar por',
+    'label' => 'Suplantar',
 ];

--- a/resources/lang/es/action.php
+++ b/resources/lang/es/action.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    'label' => 'Personificar',
+    'label' => 'Hacerse pasar por',
 ];


### PR DESCRIPTION
"Impersonate" is a word that in Spanish translates to a verbal phrase, rather than a single word. "Personificar" in my opinion is a bad translation, in English it would translate to "personify", which is not really what happens here.

In the `banner.php` file the verbal phrase "hacerse pasar por" is already being used, so I propose having the same one here in the `action.php` file.

Sources:

- https://www.wordreference.com/es/translation.asp?tranword=impersonate
- https://www.collinsdictionary.com/es/diccionario/ingles-espanol/impersonate