### PR TITLE
Fix session auth hashes clearing and impersonation process

### DIFF
--- a/src/Concerns/Impersonates.php
+++ b/src/Concerns/Impersonates.php
@@ -75,7 +75,8 @@ trait Impersonates
 
         session()->put([
             'impersonate.back_to' => $this->getBackTo() ?? request('fingerprint.path', request()->header('referer')) ?? Filament::getCurrentPanel()->getUrl(),
-            'impersonate.guard' => $this->getGuard()
+            'impersonate.guard' => $this->getGuard(),
+            'impersonate.back_to_panel' => Filament::getCurrentPanel()->getId(),
         ]);
 
         app(ImpersonateManager::class)->take(

--- a/src/FilamentImpersonateServiceProvider.php
+++ b/src/FilamentImpersonateServiceProvider.php
@@ -61,11 +61,11 @@ class FilamentImpersonateServiceProvider extends PackageServiceProvider
             'password_hash_sanctum'
         ];
 
-        if(Filament::getCurrentPanel()){
+        if (Filament::getCurrentPanel()) {
             $values[] = 'password_hash_' . Filament::getCurrentPanel()->getAuthGuard();
         }
 
-        if(Filament::getPanel(session()->get('impersonate.back_to_panel'))){
+        if (Filament::getPanel(session()->get('impersonate.back_to_panel'))) {
             $values[] = 'password_hash_' . Filament::getPanel(session()->get('impersonate.back_to_panel'))->getAuthGuard();
         }
 

--- a/src/FilamentImpersonateServiceProvider.php
+++ b/src/FilamentImpersonateServiceProvider.php
@@ -55,13 +55,21 @@ class FilamentImpersonateServiceProvider extends PackageServiceProvider
 
     protected function clearAuthHashes(): void
     {
-        session()->forget(array_unique([
+        $values = [
             'password_hash_' . session('impersonate.guard'),
-            'password_hash_' . Filament::getCurrentPanel()->getAuthGuard(),
-            'password_hash_' . Filament::getPanel(session()->get('impersonate.back_to_panel'))->getAuthGuard(),
             'password_hash_' . auth()->getDefaultDriver(),
             'password_hash_sanctum'
-        ]));
+        ];
+
+        if(Filament::getCurrentPanel()){
+            $values[] = 'password_hash_' . Filament::getCurrentPanel()->getAuthGuard();
+        }
+
+        if(Filament::getPanel(session()->get('impersonate.back_to_panel'))){
+            $values[] = 'password_hash_' . Filament::getPanel(session()->get('impersonate.back_to_panel'))->getAuthGuard();
+        }
+
+        session()->forget(array_unique($values));
     }
 
     protected function registerIcon(): void


### PR DESCRIPTION
## Description
This PR addresses issues with the session management during the impersonation process. It improves how the auth hashes are cleared from the session when impersonating users and ensures proper handling of panel switching during impersonation.

## Changes

- Enhanced the `clearAuthHashes()` method in FilamentImpersonateServiceProvider.php to properly handle session auth hash clearing
- Updated the impersonation process in Impersonates.php to ensure correct panel management during the impersonation flow

## Testing
Tested impersonation flows across multiple panels with various guard configurations
