### PR TITLE
Multi auth guards banner support

### DIFF
--- a/resources/views/components/banner.blade.php
+++ b/resources/views/components/banner.blade.php
@@ -1,6 +1,10 @@
 @props(['style', 'display', 'fixed', 'position'])
 
-@if(app('impersonate')->isImpersonating())
+@if(
+    app('impersonate')->isImpersonating()
+    &&
+    app('impersonate')->getImpersonatorGuardUsingName() === \Filament\Facades\Filament::getAuthGuard()
+)
 
 @php
 $display = $display ?? Filament\Facades\Filament::getUserName(Filament\Facades\Filament::auth()->user());

--- a/src/Concerns/Impersonates.php
+++ b/src/Concerns/Impersonates.php
@@ -5,6 +5,7 @@ namespace STS\FilamentImpersonate\Concerns;
 use Closure;
 use Filament\Facades\Filament;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
 use Lab404\Impersonate\Services\ImpersonateManager;
 use Livewire\Features\SupportRedirects\Redirector;
 
@@ -78,11 +79,16 @@ trait Impersonates
             'impersonate.guard' => $this->getGuard()
         ]);
 
+        $oldGuard = Auth::getDefaultDriver();
+        $impersonator = Filament::auth()->user();
+
         app(ImpersonateManager::class)->take(
             Filament::auth()->user(),
             $record,
             $this->getGuard()
         );
+
+        Auth::guard($oldGuard)->quietLogin($impersonator);
 
         return redirect($this->getRedirectTo());
     }


### PR DESCRIPTION
This PR is related to issues #65 and #87 

It allows to stay logged in on the impersonator's panel (without getUserName error) and also on the impersonated's panel when both are using different auth guards.