### PR TITLE
Fix banner crash in multi-panel/multi-guard setups

### DIFF
--- a/resources/views/components/banner.blade.php
+++ b/resources/views/components/banner.blade.php
@@ -1,6 +1,14 @@
 @props(['style', 'display', 'fixed', 'position'])
 
-@if(app('impersonate')->isImpersonating())
+@php
+$impersonatorGuard = app('impersonate')->getImpersonatorGuardUsingName();
+$currentPanelGuard = Filament\Facades\Filament::getAuthGuard();
+$shouldShowBanner = app('impersonate')->isImpersonating()
+    && $currentPanelGuard
+    && $impersonatorGuard === $currentPanelGuard;
+@endphp
+
+@if($shouldShowBanner)
 
 @php
 $user = Filament\Facades\Filament::auth()->user();

--- a/tests/BannerTest.php
+++ b/tests/BannerTest.php
@@ -155,6 +155,43 @@ describe('banner fixed', function () {
     });
 });
 
+describe('banner multi-guard support', function () {
+    it('does not render when impersonator guard differs from current panel guard', function () {
+        // Start impersonation
+        $action = Impersonate::make()->backTo('/admin');
+        $action->impersonate($this->targetUser);
+
+        // Simulate being in a different panel with a different guard
+        // The impersonator guard is 'web', but we'll check with a different guard
+        $impersonatorGuard = app('impersonate')->getImpersonatorGuardUsingName();
+        expect($impersonatorGuard)->toBe('web');
+
+        // Mock the scenario where we're in a different panel
+        // by directly testing the condition logic
+        $currentPanelGuard = 'admin'; // Different from 'web'
+        $shouldShow = app('impersonate')->isImpersonating()
+            && $currentPanelGuard
+            && $impersonatorGuard === $currentPanelGuard;
+
+        expect($shouldShow)->toBeFalse();
+    });
+
+    it('renders when impersonator guard matches current panel guard', function () {
+        // Start impersonation
+        $action = Impersonate::make()->backTo('/admin');
+        $action->impersonate($this->targetUser);
+
+        $impersonatorGuard = app('impersonate')->getImpersonatorGuardUsingName();
+        $currentPanelGuard = 'web'; // Same as impersonator guard
+
+        $shouldShow = app('impersonate')->isImpersonating()
+            && $currentPanelGuard
+            && $impersonatorGuard === $currentPanelGuard;
+
+        expect($shouldShow)->toBeTrue();
+    });
+});
+
 describe('banner translations', function () {
     it('contains impersonating translation key', function () {
         $action = Impersonate::make()->backTo('/admin');


### PR DESCRIPTION
## Summary

This PR fixes a crash that occurs when using multiple Filament panels with different auth guards.

**The Problem:**
When impersonating a user from Panel A (e.g., guard: `web`) into Panel B (e.g., guard: `admin`), and then navigating back to Panel A, the banner component would crash with:
```
TypeError: Filament\FilamentManager::getUserName(): Argument #1 ($user) must be of type Model, null given
```

This happens because `Filament::auth()->user()` returns `null` when you're in a different guard context than where you're authenticated.

**The Fix:**
Only render the impersonation banner when the current panel's auth guard matches the impersonator's original guard. This is a cleaner solution than trying to handle the null user gracefully.

## Changes
- Updated `banner.blade.php` to check guard match before rendering
- Added tests for multi-guard scenarios

## Related Issues
- Fixes #65
- Fixes #87
- Supersedes #114 (re-implemented for current codebase)