### PR TITLE
Fix redirect handling for modal/Livewire contexts

### DIFF
--- a/src/Actions/Impersonate.php
+++ b/src/Actions/Impersonate.php
@@ -8,7 +8,6 @@ use Filament\Facades\Filament;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\RedirectResponse;
 use Lab404\Impersonate\Services\ImpersonateManager;
-use Livewire\Features\SupportRedirects\Redirector;
 
 class Impersonate extends Action
 {
@@ -89,7 +88,7 @@ class Impersonate extends Action
             && (!method_exists($target, 'canBeImpersonated') || $target->canBeImpersonated());
     }
 
-    public function impersonate($record): bool|Redirector|RedirectResponse
+    public function impersonate($record): bool|RedirectResponse
     {
         if (!$this->canImpersonate($record)) {
             return false;
@@ -106,7 +105,15 @@ class Impersonate extends Action
             $this->getGuard()
         );
 
-        return redirect($this->getRedirectTo());
+        $redirectTo = $this->getRedirectTo();
+
+        // Use Livewire redirect when available (e.g., in modals), otherwise fall back to standard redirect
+        if ($this->getLivewire()) {
+            $this->redirect($redirectTo);
+            return true;
+        }
+
+        return redirect($redirectTo);
     }
 
     public function impersonateRecord(Authenticatable|Closure|null $record, Closure|bool|null $visible = null): static


### PR DESCRIPTION
## Summary
- Uses Livewire's `redirect()` method when action is executed in a Livewire context (e.g., modals)
- Falls back to standard `redirect()` for non-Livewire contexts
- Allows users to add modal forms/confirmations before impersonation without session/CSRF issues

## Test
Verified manually with a modal containing a dropdown selection - impersonation completes successfully and modal data is passed through to the `redirectTo` callback.

Fixes #132