### PR TITLE
Add fallback for missing session back_to in leave route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -11,7 +11,7 @@ Route::get('filament-impersonate/leave', function () {
     app(ImpersonateManager::class)->leave();
 
     return redirect(
-        session()->pull('impersonate.back_to')
+        session()->pull('impersonate.back_to') ?? '/'
     );
 })
     ->when(

--- a/tests/LeaveRouteTest.php
+++ b/tests/LeaveRouteTest.php
@@ -102,4 +102,25 @@ describe('leave route', function () {
         // The route should still work via name
         expect(route('filament-impersonate.leave'))->toContain('filament-impersonate/leave');
     });
+
+    it('redirects to fallback when session back_to is missing', function () {
+        // Start impersonation without backTo set
+        app(ImpersonateManager::class)->take(
+            $this->admin,
+            $this->targetUser,
+            'web'
+        );
+
+        // Manually clear the back_to session to simulate corruption/loss
+        session()->forget('impersonate.back_to');
+
+        expect(app(ImpersonateManager::class)->isImpersonating())->toBeTrue();
+        expect(session('impersonate.back_to'))->toBeNull();
+
+        // Leave impersonation - should fallback to '/' instead of error
+        $response = $this->get(route('filament-impersonate.leave'));
+
+        $response->assertRedirect('/');
+        expect(app(ImpersonateManager::class)->isImpersonating())->toBeFalse();
+    });
 });


### PR DESCRIPTION
## Summary
- Adds null fallback (`?? '/'`) when `session()->pull('impersonate.back_to')` returns null
- Prevents TypeError when session is corrupted or cleared unexpectedly

## Problem
In Laravel, `redirect(null)` returns a `Redirector` object instead of a `RedirectResponse`. If `session()->pull('impersonate.back_to')` returns null for any reason (session corruption, global scopes interfering, etc.), this causes:

```
TypeError: Response::setContent() expects argument #1 to be a string or null, but received an Illuminate\Routing\Redirector object
```

## Test
Added test case that simulates missing session data and verifies fallback redirect to `/`.

Might help with #139