### PR TITLE
Allow user to specify spa mode on redirect regardless of Filament configuration

### DIFF
--- a/src/Actions/Impersonate.php
+++ b/src/Actions/Impersonate.php
@@ -16,6 +16,8 @@ class Impersonate extends Action
 
     protected Closure|string|null $redirectTo = null;
 
+    protected Closure|bool|null $redirectSpa = null;
+
     protected Closure|string|null $backTo = null;
 
     protected Authenticatable|Closure|null $impersonateRecord = null;
@@ -47,9 +49,10 @@ class Impersonate extends Action
         return $this;
     }
 
-    public function redirectTo(Closure|string $redirectTo): static
+    public function redirectTo(Closure|string $redirectTo, Closure|bool|null $redirectSpa = null): static
     {
         $this->redirectTo = $redirectTo;
+        $this->redirectSpa = $redirectSpa;
 
         return $this;
     }
@@ -83,6 +86,11 @@ class Impersonate extends Action
         return $this->evaluate($this->backTo);
     }
 
+    public function getRedirectSpa(): ?bool
+    {
+        return $this->evaluate($this->redirectSpa);
+    }
+
     public function impersonate($record): bool|RedirectResponse
     {
         if (! $this->canImpersonate($record)) {
@@ -108,7 +116,9 @@ class Impersonate extends Action
         $redirectTo = $this->getRedirectTo();
 
         if ($this->getLivewire()) {
-            $this->redirect($redirectTo);
+            $redirectSpa = $this->getRedirectSpa();
+
+            $this->redirect($redirectTo, navigate: $redirectSpa);
 
             return true;
         }

--- a/src/Actions/Impersonate.php
+++ b/src/Actions/Impersonate.php
@@ -49,10 +49,10 @@ class Impersonate extends Action
         return $this;
     }
 
-    public function redirectTo(Closure|string $redirectTo, Closure|bool|null $redirectSpa = null): static
+    public function redirectTo(Closure|string $redirectTo, Closure|bool|null $spa = null): static
     {
         $this->redirectTo = $redirectTo;
-        $this->redirectSpa = $redirectSpa;
+        $this->redirectSpa = $spa;
 
         return $this;
     }

--- a/src/Actions/Impersonate.php
+++ b/src/Actions/Impersonate.php
@@ -49,12 +49,28 @@ class Impersonate extends Action
         return $this;
     }
 
-    public function redirectTo(Closure|string $redirectTo, Closure|bool|null $spa = null): static
+    public function redirectTo(Closure|string $redirectTo): static
     {
         $this->redirectTo = $redirectTo;
-        $this->redirectSpa = $spa;
 
         return $this;
+    }
+
+    public function spa(Closure|bool $condition = true): static
+    {
+        $this->redirectSpa = $condition;
+
+        return $this;
+    }
+
+    public function withSpa(): static
+    {
+        return $this->spa(true);
+    }
+
+    public function withoutSpa(): static
+    {
+        return $this->spa(false);
     }
 
     public function backTo(Closure|string $backTo): static
@@ -116,9 +132,11 @@ class Impersonate extends Action
         $redirectTo = $this->getRedirectTo();
 
         if ($this->getLivewire()) {
-            $redirectSpa = $this->getRedirectSpa();
+            $spa = $this->getRedirectSpa();
 
-            $this->redirect($redirectTo, navigate: $redirectSpa);
+            $spa === null
+                ? $this->redirect($redirectTo)
+                : $this->redirect($redirectTo, navigate: $spa);
 
             return true;
         }

--- a/tests/ImpersonateActionTest.php
+++ b/tests/ImpersonateActionTest.php
@@ -95,6 +95,36 @@ describe('guard', function () {
     });
 });
 
+describe('redirectSpa', function () {
+    it('returns null when redirectSpa not set', function () {
+        $action = Impersonate::make()
+            ->redirectTo('/custom-path');
+
+        expect($action->getRedirectSpa())->toBeNull();
+    });
+
+    it('returns true when redirectSpa set to true', function () {
+        $action = Impersonate::make()
+            ->redirectTo('/custom-path', redirectSpa: true);
+
+        expect($action->getRedirectSpa())->toBeTrue();
+    });
+
+    it('returns false when redirectSpa set to false', function () {
+        $action = Impersonate::make()
+            ->redirectTo('/custom-path', redirectSpa: false);
+
+        expect($action->getRedirectSpa())->toBeFalse();
+    });
+
+    it('evaluates closure for redirectSpa', function () {
+        $action = Impersonate::make()
+            ->redirectTo('/custom-path', redirectSpa: fn () => false);
+
+        expect($action->getRedirectSpa())->toBeFalse();
+    });
+});
+
 describe('backTo', function () {
     it('returns custom backTo URL when set', function () {
         $action = Impersonate::make()

--- a/tests/ImpersonateActionTest.php
+++ b/tests/ImpersonateActionTest.php
@@ -105,21 +105,21 @@ describe('redirectSpa', function () {
 
     it('returns true when redirectSpa set to true', function () {
         $action = Impersonate::make()
-            ->redirectTo('/custom-path', redirectSpa: true);
+            ->redirectTo('/custom-path', spa: true);
 
         expect($action->getRedirectSpa())->toBeTrue();
     });
 
     it('returns false when redirectSpa set to false', function () {
         $action = Impersonate::make()
-            ->redirectTo('/custom-path', redirectSpa: false);
+            ->redirectTo('/custom-path', spa: false);
 
         expect($action->getRedirectSpa())->toBeFalse();
     });
 
     it('evaluates closure for redirectSpa', function () {
         $action = Impersonate::make()
-            ->redirectTo('/custom-path', redirectSpa: fn () => false);
+            ->redirectTo('/custom-path', spa: fn () => false);
 
         expect($action->getRedirectSpa())->toBeFalse();
     });

--- a/tests/ImpersonateActionTest.php
+++ b/tests/ImpersonateActionTest.php
@@ -95,31 +95,50 @@ describe('guard', function () {
     });
 });
 
-describe('redirectSpa', function () {
-    it('returns null when redirectSpa not set', function () {
+describe('spa', function () {
+    it('returns null when spa not set', function () {
         $action = Impersonate::make()
             ->redirectTo('/custom-path');
 
         expect($action->getRedirectSpa())->toBeNull();
     });
 
-    it('returns true when redirectSpa set to true', function () {
+    it('returns true when spa() called with no argument', function () {
         $action = Impersonate::make()
-            ->redirectTo('/custom-path', spa: true);
+            ->redirectTo('/custom-path')
+            ->spa();
 
         expect($action->getRedirectSpa())->toBeTrue();
     });
 
-    it('returns false when redirectSpa set to false', function () {
+    it('returns true when withSpa() called', function () {
         $action = Impersonate::make()
-            ->redirectTo('/custom-path', spa: false);
+            ->redirectTo('/custom-path')
+            ->withSpa();
+
+        expect($action->getRedirectSpa())->toBeTrue();
+    });
+
+    it('returns false when withoutSpa() called', function () {
+        $action = Impersonate::make()
+            ->redirectTo('/custom-path')
+            ->withoutSpa();
 
         expect($action->getRedirectSpa())->toBeFalse();
     });
 
-    it('evaluates closure for redirectSpa', function () {
+    it('returns false when spa(false) called', function () {
         $action = Impersonate::make()
-            ->redirectTo('/custom-path', spa: fn () => false);
+            ->redirectTo('/custom-path')
+            ->spa(false);
+
+        expect($action->getRedirectSpa())->toBeFalse();
+    });
+
+    it('evaluates closure for spa', function () {
+        $action = Impersonate::make()
+            ->redirectTo('/custom-path')
+            ->spa(fn () => false);
 
         expect($action->getRedirectSpa())->toBeFalse();
     });


### PR DESCRIPTION
When a panel has `->spa()` enabled and `redirectTo` points outside of Filament — e.g. custom Livewire pages with their own layout files and livewire injection — it's useful to be able to opt out of SPA navigation for that redirect.

The `redirectTo()` method would now accept an optional `spa` parameter:

```php
Impersonate::make()
    ->redirectTo('/custom-page', spa: false)
```

When not set, the panel's SPA configuration e.g. in `AdminPanelProvider` is used as before.