### PR TITLE
Change cookie expiration date when Impersonating

### DIFF
--- a/src/ImpersonateManager.php
+++ b/src/ImpersonateManager.php
@@ -189,6 +189,8 @@ class ImpersonateManager
         }
 
         session()->put(static::REMEMBER_PREFIX, [$key, $val]);
+
+        cookie()->queue(cookie($key, '', -2628000));
     }
 
     protected function extractAuthCookieFromSession(): void

--- a/src/ImpersonateManager.php
+++ b/src/ImpersonateManager.php
@@ -190,7 +190,7 @@ class ImpersonateManager
 
         session()->put(static::REMEMBER_PREFIX, [$key, $val]);
 
-        cookie()->queue(cookie($key, '', -2628000));
+        cookie()->queue(cookie()->forget($key));
     }
 
     protected function extractAuthCookieFromSession(): void


### PR DESCRIPTION
This change resolves an odd behavior that occurs when there are multiple panels with multiple authentication guards.

When you switch from one panel to another after invalidating the token, Laravel attempts to refresh the current token with the remember me token. 

This invalidates the token for the other panel, breaking the impersonating banner.