### PR TITLE
Scope Login/Logout impersonation clear to the impersonator's guard

### DIFF
--- a/src/FilamentImpersonateServiceProvider.php
+++ b/src/FilamentImpersonateServiceProvider.php
@@ -37,8 +37,8 @@ class FilamentImpersonateServiceProvider extends PackageServiceProvider
 
         Event::listen(EnterImpersonation::class, fn () => $this->clearAuthHashes());
         Event::listen(LeaveImpersonation::class, fn () => $this->clearAuthHashes());
-        Event::listen(Login::class, fn () => Impersonation::clear());
-        Event::listen(Logout::class, fn () => Impersonation::clear());
+        Event::listen(Login::class, fn (Login $event) => $this->clearImpersonationForGuard($event->guard));
+        Event::listen(Logout::class, fn (Logout $event) => $this->clearImpersonationForGuard($event->guard));
 
         $this->registerIcon();
     }
@@ -51,6 +51,35 @@ class FilamentImpersonateServiceProvider extends PackageServiceProvider
         );
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'impersonate');
+    }
+
+    /**
+     * Clear impersonation in response to an auth event, but only when the event
+     * belongs to a guard involved in the active impersonation.
+     *
+     * Apps that share a single session across multiple guards (e.g. an admin
+     * guard alongside a separate customer/storefront guard) would otherwise have
+     * an active impersonation silently torn down when an unrelated guard fires
+     * Login/Logout — a customer logging in on the storefront, say. The
+     * impersonator's own session key is untouched, so they remain authenticated
+     * as the impersonated user but isImpersonating() returns false, leaving them
+     * with no banner and no way to leave. Only the impersonator's guard chain may
+     * end the impersonation.
+     */
+    protected function clearImpersonationForGuard(?string $guard): void
+    {
+        if (Impersonation::isImpersonating()) {
+            $impersonationGuards = array_filter([
+                Impersonation::getImpersonatorGuardName(),
+                Impersonation::getImpersonatorGuardUsingName(),
+            ]);
+
+            if ($guard !== null && $impersonationGuards !== [] && ! in_array($guard, $impersonationGuards, true)) {
+                return;
+            }
+        }
+
+        Impersonation::clear();
     }
 
     protected function clearAuthHashes(): void

--- a/tests/ImpersonationClearOnAuthEventTest.php
+++ b/tests/ImpersonationClearOnAuthEventTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\Events\Logout;
+use STS\FilamentImpersonate\Facades\Impersonation;
+use STS\FilamentImpersonate\Tests\User;
+
+beforeEach(function () {
+    $this->admin = User::create([
+        'name' => 'Admin',
+        'email' => 'admin@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $this->targetUser = User::create([
+        'name' => 'Target User',
+        'email' => 'target@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $this->actingAs($this->admin);
+});
+
+afterEach(function () {
+    if (Impersonation::isImpersonating()) {
+        Impersonation::leave();
+    }
+});
+
+it('keeps the impersonation when a login fires on an unrelated guard', function () {
+    Impersonation::enter($this->admin, $this->targetUser, 'web');
+
+    // A different guard sharing the same session (e.g. a customer/storefront
+    // guard) authenticates. This must not tear down the admin impersonation.
+    event(new Login('customer', $this->targetUser, false));
+
+    expect(Impersonation::isImpersonating())->toBeTrue();
+});
+
+it('keeps the impersonation when a logout fires on an unrelated guard', function () {
+    Impersonation::enter($this->admin, $this->targetUser, 'web');
+
+    event(new Logout('customer', $this->targetUser));
+
+    expect(Impersonation::isImpersonating())->toBeTrue();
+});
+
+it('clears the impersonation when a fresh login fires on the impersonator guard', function () {
+    Impersonation::enter($this->admin, $this->targetUser, 'web');
+
+    event(new Login('web', $this->admin, false));
+
+    expect(Impersonation::isImpersonating())->toBeFalse();
+});
+
+it('clears the impersonation when a logout fires on the impersonator guard', function () {
+    Impersonation::enter($this->admin, $this->targetUser, 'web');
+
+    event(new Logout('web', $this->targetUser));
+
+    expect(Impersonation::isImpersonating())->toBeFalse();
+});
+
+it('still clears on login when not impersonating', function () {
+    expect(Impersonation::isImpersonating())->toBeFalse();
+
+    event(new Login('customer', $this->targetUser, false));
+
+    expect(Impersonation::isImpersonating())->toBeFalse();
+});


### PR DESCRIPTION
## Problem

`FilamentImpersonateServiceProvider::registeringPackage()` clears impersonation on **every** `Login`/`Logout` event, ignoring which guard fired it:

```php
Event::listen(Login::class,  fn () => Impersonation::clear());
Event::listen(Logout::class, fn () => Impersonation::clear());
```

In apps that share a single session across **multiple guards** (e.g. an admin guard alongside a separate `customer`/storefront guard on the same domain), this is unsafe. While an admin is impersonating, an unrelated guard authenticating — a customer logging in on the storefront, or a "remember me" recaller silently re-authenticating on a plain GET — fires a `Login`/`Logout` and tears the impersonation down.

The impersonator's own session login key is left untouched, so they remain authenticated **as the impersonated user**, but `isImpersonating()` now returns `false`: the banner disappears and there's no way to leave. The admin is silently stuck as the impersonated user.

## Fix

Only end the impersonation when the auth event belongs to a guard involved in the impersonation (the impersonator's guard, or the guard being used):

```php
protected function clearImpersonationForGuard(?string $guard): void
{
    if (Impersonation::isImpersonating()) {
        $impersonationGuards = array_filter([
            Impersonation::getImpersonatorGuardName(),
            Impersonation::getImpersonatorGuardUsingName(),
        ]);

        if ($guard !== null && $impersonationGuards !== [] && ! in_array($guard, $impersonationGuards, true)) {
            return;
        }
    }

    Impersonation::clear();
}
```

## Backward compatibility

- **Single-guard apps:** the event guard always matches the impersonator guard, so behaviour is identical.
- **Not impersonating:** falls through to `Impersonation::clear()` exactly as before (e.g. clearing stray keys on a fresh login).
- **Impersonator's own guard logs in/out:** still clears — a real login/logout ends the impersonation as expected.
- Only a **foreign** guard's auth event is now ignored.

## Tests

Adds `tests/ImpersonationClearOnAuthEventTest.php` covering both paths (unrelated guard preserves; impersonator guard clears; not-impersonating unchanged). Full suite passes locally (135 passed).